### PR TITLE
Only ask on cellular connection

### DIFF
--- a/background/ask-before-download.js
+++ b/background/ask-before-download.js
@@ -215,8 +215,17 @@ function isLargeOctetStream(contentType, fileSize){
     }
 }
 
+function isOnCellular() {
+    var connection = navigator.connection || navigator.mozConnection;
+    return connection && connection.type === 'cellular';
+}
+
 function filterRequest(request) {
     //log("filterRequest");
+    if (!isOnCellular()) {
+        return {};
+    }
+
     /* Maybe only process 200 and 206 is enough */
     if (!(request.statusCode >= 200 && request.statusCode < 300)) {
         return {};


### PR DESCRIPTION
When browsing website containing video or sound such as youtube, the dialog popup [I know there is a remember this site option but that is still annoying].  That is good for cellular network but not necessary, for me, over wifi.  So I would like to bypass it over wifi.